### PR TITLE
Gemini 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To get started with CrewAI, follow these simple steps:
 
 ### 1. Installation
 
-Ensure you have Python >=3.10 <=3.12 installed on your system. CrewAI uses [UV](https://docs.astral.sh/uv/) for dependency management and package handling, offering a seamless setup and execution experience.
+Ensure you have Python >=3.10 <3.13 installed on your system. CrewAI uses [UV](https://docs.astral.sh/uv/) for dependency management and package handling, offering a seamless setup and execution experience.
 
 First, install CrewAI:
 

--- a/docs/concepts/llms.mdx
+++ b/docs/concepts/llms.mdx
@@ -29,7 +29,7 @@ Large Language Models (LLMs) are the core intelligence behind CrewAI agents. The
 
 ## Available Models and Their Capabilities
 
-Here's a detailed breakdown of supported models and their capabilities, you can compare performance at [lmarena.ai](https://lmarena.ai/):
+Here's a detailed breakdown of supported models and their capabilities, you can compare performance at [lmarena.ai](https://lmarena.ai/?leaderboard) and [artificialanalysis.ai](https://artificialanalysis.ai/):
 
 <Tabs>
   <Tab title="OpenAI">
@@ -121,12 +121,18 @@ Here's a detailed breakdown of supported models and their capabilities, you can 
   <Tab title="Gemini">
     | Model | Context Window | Best For |
     |-------|---------------|-----------|
-    | Gemini 1.5 Flash | 1M tokens | Balanced multimodal model, good for most tasks |
-    | Gemini 1.5 Flash 8B | 1M tokens | Fastest, most cost-efficient, good for high-frequency tasks |
-    | Gemini 1.5 Pro | 2M tokens | Best performing, wide variety of reasoning tasks including logical reasoning, coding, and creative collaboration |
+    | gemini-2.0-flash-exp | 1M tokens | Higher quality at faster speed, multimodal model, good for most tasks |
+    | gemini-1.5-flash | 1M tokens | Balanced multimodal model, good for most tasks |
+    | gemini-1.5-flash-8B | 1M tokens | Fastest, most cost-efficient, good for high-frequency tasks |
+    | gemini-1.5-pro | 2M tokens | Best performing, wide variety of reasoning tasks including logical reasoning, coding, and creative collaboration |
 
     <Tip>
       Google's Gemini models are all multimodal, supporting audio, images, video and text, supporting context caching, json schema, function calling, etc.
+
+      These models are available via API_KEY from 
+      [The Gemini API](https://ai.google.dev/gemini-api/docs) and also from 
+      [Google Cloud Vertex](https://cloud.google.com/vertex-ai/generative-ai/docs/migrate/migrate-google-ai) as part of the
+      [Model Garden](https://cloud.google.com/vertex-ai/generative-ai/docs/model-garden/explore-models).
     </Tip>
   </Tab>
   <Tab title="Groq">
@@ -135,7 +141,6 @@ Here's a detailed breakdown of supported models and their capabilities, you can 
     | Llama 3.1 70B/8B | 131,072 tokens | High-performance, large context tasks |
     | Llama 3.2 Series | 8,192 tokens | General-purpose tasks |
     | Mixtral 8x7B | 32,768 tokens | Balanced performance and context |
-    | Gemma Series | 8,192 tokens | Efficient, smaller-scale tasks |
 
     <Tip>
       Groq is known for its fast inference speeds, making it suitable for real-time applications.
@@ -146,7 +151,7 @@ Here's a detailed breakdown of supported models and their capabilities, you can 
     |----------|---------------|--------------|
     | Deepseek Chat | 128,000 tokens | Specialized in technical discussions |
     | Claude 3 | Up to 200K tokens | Strong reasoning, code understanding |
-    | Gemini | Varies by model | Multimodal capabilities |
+    | Gemma Series | 8,192 tokens | Efficient, smaller-scale tasks |
 
     <Info>
       Provider selection should consider factors like:

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -7,7 +7,7 @@ icon: wrench
 <Note>
   **Python Version Requirements**
   
-  CrewAI requires `Python >=3.10 and <=3.12`. Here's how to check your version:
+  CrewAI requires `Python >=3.10 and <3.13`. Here's how to check your version:
   ```bash
   python3 --version
   ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "crewai"
 version = "0.86.0"
 description = "Cutting-edge framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together seamlessly, tackling complex tasks."
 readme = "README.md"
-requires-python = ">=3.10,<=3.12"
+requires-python = ">=3.10,<3.13"
 authors = [
     { name = "Joao Moura", email = "joao@crewai.com" }
 ]

--- a/src/crewai/cli/templates/crew/README.md
+++ b/src/crewai/cli/templates/crew/README.md
@@ -4,7 +4,7 @@ Welcome to the {{crew_name}} Crew project, powered by [crewAI](https://crewai.co
 
 ## Installation
 
-Ensure you have Python >=3.10 <=3.12 installed on your system. This project uses [UV](https://docs.astral.sh/uv/) for dependency management and package handling, offering a seamless setup and execution experience.
+Ensure you have Python >=3.10 <3.13 installed on your system. This project uses [UV](https://docs.astral.sh/uv/) for dependency management and package handling, offering a seamless setup and execution experience.
 
 First, if you haven't already, install uv:
 

--- a/src/crewai/cli/templates/crew/pyproject.toml
+++ b/src/crewai/cli/templates/crew/pyproject.toml
@@ -3,7 +3,7 @@ name = "{{folder_name}}"
 version = "0.1.0"
 description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
-requires-python = ">=3.10,<=3.12"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "crewai[tools]>=0.86.0,<1.0.0"
 ]

--- a/src/crewai/cli/templates/flow/README.md
+++ b/src/crewai/cli/templates/flow/README.md
@@ -4,7 +4,7 @@ Welcome to the {{crew_name}} Crew project, powered by [crewAI](https://crewai.co
 
 ## Installation
 
-Ensure you have Python >=3.10 <=3.12 installed on your system. This project uses [UV](https://docs.astral.sh/uv/) for dependency management and package handling, offering a seamless setup and execution experience.
+Ensure you have Python >=3.10 <3.13 installed on your system. This project uses [UV](https://docs.astral.sh/uv/) for dependency management and package handling, offering a seamless setup and execution experience.
 
 First, if you haven't already, install uv:
 

--- a/src/crewai/cli/templates/flow/pyproject.toml
+++ b/src/crewai/cli/templates/flow/pyproject.toml
@@ -3,7 +3,7 @@ name = "{{folder_name}}"
 version = "0.1.0"
 description = "{{name}} using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
-requires-python = ">=3.10,<=3.12"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "crewai[tools]>=0.86.0,<1.0.0",
 ]

--- a/src/crewai/cli/templates/tool/README.md
+++ b/src/crewai/cli/templates/tool/README.md
@@ -5,7 +5,7 @@ custom tools to power up your crews.
 
 ## Installing
 
-Ensure you have Python >=3.10 <=3.12 installed on your system. This project
+Ensure you have Python >=3.10 <3.13 installed on your system. This project
 uses [UV](https://docs.astral.sh/uv/) for dependency management and package
 handling, offering a seamless setup and execution experience.
 

--- a/src/crewai/cli/templates/tool/pyproject.toml
+++ b/src/crewai/cli/templates/tool/pyproject.toml
@@ -3,7 +3,7 @@ name = "{{folder_name}}"
 version = "0.1.0"
 description = "Power up your crews with {{folder_name}}"
 readme = "README.md"
-requires-python = ">=3.10,<=3.12"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "crewai[tools]>=0.86.0"
 ]

--- a/src/crewai/llm.py
+++ b/src/crewai/llm.py
@@ -44,6 +44,7 @@ LLM_CONTEXT_WINDOW_SIZES = {
     "o1-preview": 128000,
     "o1-mini": 128000,
     # gemini
+    "gemini-2.0-flash": 1048576,
     "gemini-1.5-pro": 2097152,
     "gemini-1.5-flash": 1048576,
     "gemini-1.5-flash-8b": 1048576,

--- a/tests/cli/deploy/test_deploy_main.py
+++ b/tests/cli/deploy/test_deploy_main.py
@@ -231,7 +231,7 @@ class TestDeployCommand(unittest.TestCase):
         [project]
         name = "test_project"
         version = "0.1.0"
-        requires-python = ">=3.10,<=3.12"
+        requires-python = ">=3.10,<3.13"
         dependencies = ["crewai"]
         """,
     )
@@ -250,7 +250,7 @@ class TestDeployCommand(unittest.TestCase):
     [project]
     name = "test_project"
     version = "0.1.0"
-    requires-python = ">=3.10,<=3.12"
+    requires-python = ">=3.10,<3.13"
     dependencies = ["crewai"]
     """,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,10 @@
 version = 1
-requires-python = ">=3.10, <=3.12"
+requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version < '3.11'",
     "python_full_version == '3.11.*'",
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.12' and python_full_version < '3.12.4'",
+    "python_full_version >= '3.12.4'",
 ]
 
 [[package]]


### PR DESCRIPTION
Update llms.mdx (Gemini 2.0)
- Add Gemini 2.0 flash to Gemini table.
- Add link to 2 hosting paths for Gemini in Tip.
- Change to lower case model slugs vs names, user convenience.
- Add https://artificialanalysis.ai/ as alternate leaderboard.
- Move Gemma to "other" tab.

Update llm.py (gemini 2.0)
- Add setting for Gemini 2.0 context window to llm.py